### PR TITLE
key fidelity test. match code formatting better.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -76,9 +76,13 @@ return function (db, masterDb, id) {
   var clock = {} //remember latest version from each dep.
 
   masterDb = masterDb || 'master'
-  if('string' === typeof masterDb)
-    masterDb = db.sublevel(masterDb, {keyEncoding: 'utf8', valueEncoding: 'utf8'})
-  var clockDb = masterDb.sublevel('clock', {keyEncoding: 'utf8', valueEncoding: 'utf8'})
+  if('string' === typeof masterDb) {
+    masterDb = db.sublevel(masterDb, {keyEncoding: 'utf8',
+      valueEncoding: 'utf8'})
+  }
+  var clockDb = masterDb.sublevel('clock', {keyEncoding: 'utf8',
+    valueEncoding: 'utf8'
+  })
 
   //on insert, remember which keys where updated when.
   db.pre(function (op, add, batch) {
@@ -243,8 +247,10 @@ return function (db, masterDb, id) {
         if(clock[op.id] > op.ts) return
         return [
           op,
-          {key: op.id+'\x00'+op.ts, value: op.key, type: 'put', prefix: masterDb},
-          {key: op.id, value: op.ts, type: 'put', prefix: clockDb}
+          {key: op.id+'\x00'+op.ts, value: op.key, type: 'put',
+            prefix: masterDb, keyEncoding: 'utf8', valueEncoding: 'utf8'},
+          {key: op.id, value: op.ts, type: 'put', prefix: clockDb,
+            keyEncoding: 'utf8', valueEncoding: 'utf8'}
         ]
       }),
       pull.filter(Boolean),

--- a/test/key-fidelity.js
+++ b/test/key-fidelity.js
@@ -33,7 +33,7 @@ test('fills', function (t) {
 // store the data that is sent from one master to the other
 var wireData = {}
 
-run = function (key) {
+run = function (key, expectedWireCalls) {
   test('replicates', function (t) {
     db1 = sublevel(levelup('key-fidelity_db1', opts))
     db2 = sublevel(levelup('key-fidelity_db2', opts))
@@ -41,40 +41,52 @@ run = function (key) {
     m2 = replicate(db2, 'master', 'M4')
 
     // replicate databases
-    m1s = m1.createStream({tail: true})
-    m1s.pipe(m2.createStream({tail: true})).pipe(m1s)
+    var m1s = m1.createStream({tail: true})
+    var m2s = m2.createStream({tail: true})
+
+    m1s.pipe(m2s).pipe(m1s)
     m1s.on('data', function(data){
       wireData[key] = wireData[key] || {};
       wireData[key][data] = true;
     })
 
-    setTimeout(function () {
+    var wireCallTimes = 1;
+
+    m2s.on('data', function () {
+      console.log('data', wireCallTimes, expectedWireCalls)
+      if (wireCallTimes < expectedWireCalls) return wireCallTimes++;
       // collect result
       var db1result = ''
       var db2result = ''
 
-      db1.createReadStream().on('data', function(data){
-        db1result += JSON.stringify(data)
-      })
-      db2.createReadStream().on('data', function(data){
-        db2result += JSON.stringify(data)
-      })
+      var s1 = db1.createReadStream()
+      var s2 = db2.createReadStream()
 
-      setTimeout(function () {
+      s1.on('data', function(data){ db1result += JSON.stringify(data) })
+      s2.on('data', function(data){ db2result += JSON.stringify(data) })
+
+      s2.on('end', done)
+      s1.on('end', done)
+
+      var doneTimes = 0
+      function done() {
+        if (doneTimes < 1) return doneTimes++;
+        console.log('done', doneTimes)
+
         t.ok(db1result, 'db1 has content')
         t.equal(db1result, db2result, 'contents matches')
 
         db1.close(function(){ db2.close(function(){ t.end() }) })
-      }, 100)
-    }, 100)
+      }
+    })
   })
 }
 
 // replicate several times
-run('1')
-run('2')
-run('3')
-run('4')
+run('1', 2)
+run('2', 1)
+run('3', 1)
+run('4', 1)
 
 test('only info about key "foo" is sent', function(t){
   keys = []

--- a/test/key-fidelity.js
+++ b/test/key-fidelity.js
@@ -53,7 +53,6 @@ run = function (key, expectedWireCalls) {
     var wireCallTimes = 1;
 
     m2s.on('data', function () {
-      console.log('data', wireCallTimes, expectedWireCalls)
       if (wireCallTimes < expectedWireCalls) return wireCallTimes++;
       // collect result
       var db1result = ''
@@ -71,7 +70,6 @@ run = function (key, expectedWireCalls) {
       var doneTimes = 0
       function done() {
         if (doneTimes < 1) return doneTimes++;
-        console.log('done', doneTimes)
 
         t.ok(db1result, 'db1 has content')
         t.equal(db1result, db2result, 'contents matches')

--- a/test/key-fidelity.js
+++ b/test/key-fidelity.js
@@ -1,0 +1,94 @@
+var levelup = require('level-test')()
+  , replicate = require('../')
+  , sublevel = require('level-sublevel')
+  , test = require('tape')
+  , opts = {keyEncoding: 'utf8', valueEncoding: 'json', clean: false}
+
+var db1, db2, m1, m2;
+
+// necessary to clean up databases before test
+test('setup', function (t) {
+  db1 = sublevel(levelup('key-fidelity_db1'))
+  db2 = sublevel(levelup('key-fidelity_db2'))
+  db1.close(function(){
+    db2.close(function(){
+      t.end()
+    })
+  })
+})
+
+test('fills', function (t) {
+  db1 = sublevel(levelup('key-fidelity_db1', opts))
+  db2 = sublevel(levelup('key-fidelity_db2', opts))
+  m1 = replicate(db1, 'master', 'M1')
+  m2 = replicate(db2, 'master', 'M2')
+
+  // add one document
+  db1.put('foo', {bar: 'baz'}, function (err) {
+    if (err) console.log('err', err);
+    db1.close(function(){ db2.close(function(){ t.end() }) })
+  });
+})
+
+// store the data that is sent from one master to the other
+var wireData = {}
+
+run = function (key) {
+  test('replicates', function (t) {
+    db1 = sublevel(levelup('key-fidelity_db1', opts))
+    db2 = sublevel(levelup('key-fidelity_db2', opts))
+    m1 = replicate(db1, 'master', 'M3')
+    m2 = replicate(db2, 'master', 'M4')
+
+    // replicate databases
+    m1s = m1.createStream({tail: true})
+    m1s.pipe(m2.createStream({tail: true})).pipe(m1s)
+    m1s.on('data', function(data){
+      wireData[key] = wireData[key] || {};
+      wireData[key][data] = true;
+    })
+
+    setTimeout(function () {
+      // collect result
+      var db1result = ''
+      var db2result = ''
+
+      db1.createReadStream().on('data', function(data){
+        db1result += JSON.stringify(data)
+      })
+      db2.createReadStream().on('data', function(data){
+        db2result += JSON.stringify(data)
+      })
+
+      setTimeout(function () {
+        t.ok(db1result, 'db1 has content')
+        t.equal(db1result, db2result, 'contents matches')
+
+        db1.close(function(){ db2.close(function(){ t.end() }) })
+      }, 100)
+    }, 100)
+  })
+}
+
+// replicate several times
+run('1')
+run('2')
+run('3')
+run('4')
+
+test('only info about key "foo" is sent', function(t){
+  keys = []
+  for (k in wireData) {
+    for (kk in wireData[k]) {
+      var obj = JSON.parse(kk)
+      console.log('result:', k, obj)
+      // ignore anything without 'key' set
+      if (obj.key) keys.push(obj.key);
+    }
+  }
+  // there should be only one key: foo
+  console.log('result:', keys)
+  t.equal(keys.length, 1)
+  t.equal(keys[keys.length-1], 'foo')
+  t.end()
+})


### PR DESCRIPTION
I believe I handled the issues discussed in #16. I didn't find a way to make this test fail and pass in the same way using the `populate` helper. As I only need one value to show this bug and it only happens when you close and re-open the database, `populate` didn't make the test any simpler. I think the important thing is this test shows the bug I found being solved, right?
