### PR TITLE
allow replication of sublevels (nonbreaking)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - '0.8'
+  - '0.10'

--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ var Replicate = require('level-replicate/msgpack')
 
 var db = SubLevel(level('/tmp/example-slave'))
 var master = Replicate(db, 'master', "MASTER-2")
+```
 
+## Replicating Sublevels Recursively
 
+```js
+//install Master plugin with the `recursive` option set to `true`.
+var master = Replicate(db, 'master', "MASTER-1", {recursive: true})
+
+// changes made to all sublevels of `db` will replicate!
+db.sublevel('documents').put('foo', {bar: 'baz'}, function() { ... })
 ```
 
 <!--

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# level-replicate
+# level-replicate [![build status](https://secure.travis-ci.org/dominictarr/level-replicate.png)](http://travis-ci.org/dominictarr/level-replicate)
 
 master-master replication with levelup.
 

--- a/inject.js
+++ b/inject.js
@@ -71,7 +71,7 @@ function pCont (continuable) {
 
 module.exports = function (serialize) {
 
-return function (db, masterDb, id) {
+return function (db, masterDb, id, preOpts) {
 
   var clock = {} //remember latest version from each dep.
 
@@ -81,7 +81,12 @@ return function (db, masterDb, id) {
   var clockDb = masterDb.sublevel('clock', {keyEncoding: 'utf8', valueEncoding: 'utf8'})
 
   //on insert, remember which keys where updated when.
-  db.pre(function (op, add, batch) {
+  if (preOpts) {
+    db.pre(preOpts, preHook)
+  } else {
+    db.pre(preHook)
+  }
+  function preHook (op, add, batch) {
     var prefix = masterDb.prefix()
 
     if(!find(batch, function (_op) {
@@ -96,7 +101,7 @@ return function (db, masterDb, id) {
         valueEncoding: 'utf8', keyEncoding: 'utf8'
       })
     }
-  })
+  }
 
   //cleanup old records.
   //run this every so often if you have lots of overwrites.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "level-sublevel": ">=5.0.1 <6",
     "random-name": "~0.1.0",
-    "rimraf": "^2.2.6",
+    "rimraf": "~2.2.6",
     "pull-crypto": "~1.0",
     "pull-zip": "1",
     "tape": "~2.10.2",

--- a/test/net-replicate-binary.js
+++ b/test/net-replicate-binary.js
@@ -35,12 +35,10 @@ u.generate(d1, {
     return op
   }
 }) (function () {
-  setTimeout(function () {
-    s1.end()
-  }, 500)
+
 })
 
-//d2.put('y'+Math.random(), 'foo', function () {})
-
-u.eventuallyConsistent(d1, d2, 100)
+u.eventuallyConsistent(d1, d2, 100, function () {
+  s1.end();
+})
 

--- a/test/net-replicate-msgpack.js
+++ b/test/net-replicate-msgpack.js
@@ -43,13 +43,9 @@ para(
   u.generate(d1, {create: d('a')}),
   u.generate(d3, {create: d('b')})
 ) (function () {
-    setTimeout(function () {
-      s1.end();
-      //s3.end()
-    }, 1000)
-  })
 
-//u.eventuallyConsistent(d1, d2)
-u.eventuallyConsistent(d1, d3)
-//u.eventuallyConsistent(d2, d3)
+})
 
+u.eventuallyConsistent(d1, d3, 100, function () {
+  s1.end();
+})

--- a/test/replicate-sublevels.js
+++ b/test/replicate-sublevels.js
@@ -1,0 +1,107 @@
+var level    = require('level-test')()
+var test     = require('tape')
+var sublevel = require('level-sublevel')
+var pl       = require('pull-level')
+var pull     = require('pull-stream')
+var para     = require('continuable-para')
+var series   = require('continuable-series')
+
+var master   = require('../')
+
+var all      = require('./util').all
+
+function put (db, key, value) {
+  return function (cb) {
+    db.put(key, value, cb)
+  }
+}
+
+function replicate (m1, m2) {
+  return function (cb) {
+    m1.createMasterStream()
+      .pipe(m2.createSlaveStream(cb))
+  }
+}
+
+test('replicate sublevels 1', function (t) {
+  var db1 = sublevel(level('replicate_1'))
+  var db2 = sublevel(level('replicate_2'))
+
+  var sub1 = db1.sublevel('sub1').sublevel('sub2')
+
+  var m1 = master(db1, 'master', "M1", '\xffsub1\xff')
+  var m2 = master(db2, 'master', "M2", '\xffsub1\xff')
+
+  series(
+    put(sub1, 'foo', new Date()),
+    replicate(m1, m2),
+    para(all(db1), all(db2))
+  )(function (err, all) {
+    t.notOk(err)
+    //assert that both databases are equal!
+    console.log(all)
+    t.deepEqual(all[0], all[1])
+    t.end()
+  })
+})
+
+test('replicate sublevels 2', function (t) {
+
+  var db1 = sublevel(level('replicate2_1'))
+  var db2 = sublevel(level('replicate2_2'))
+
+  var sub1 = db1.sublevel('data').sublevel('sub1')
+  var sub2 = db2.sublevel('data').sublevel('sub2')
+
+  var m1 = master(db1, 'master', "M1", db1.sublevel('data').prefix())
+  var m2 = master(db2, 'master', "M2", db2.sublevel('data').prefix())
+
+  series(
+    para(
+      put(sub1, 'foo', new Date()),
+      put(sub2, 'bar', new Date())
+    ),
+    para(replicate(m1, m2), replicate(m2, m1)),
+    para(all (db1), all(db2))
+  )(function (err, all) {
+    t.notOk(err)
+    //assert that both databases are equal!
+    console.log(all)
+    t.deepEqual(all[0], all[1])
+    t.end()
+  })
+})
+
+test('replicate sublevels 3', function (t) {
+
+  var db1 = sublevel(level('replicate3_1'))
+  var db2 = sublevel(level('replicate3_2'))
+  var db3 = sublevel(level('replicate3_3'))
+
+  var sub1 = db1.sublevel('data').sublevel('sub1')
+  var sub2 = db2.sublevel('data').sublevel('sub2')
+  var sub3 = db3.sublevel('data').sublevel('sub2')
+
+  var m1 = master(db1, 'master', "M1", db1.sublevel('data').prefix())
+  var m2 = master(db2, 'master', "M2", db2.sublevel('data').prefix())
+  var m3 = master(db3, 'master', "M3", db3.sublevel('data').prefix())
+
+  series (
+    para (
+      put (sub1, 'foo', new Date()),
+      put (sub2, 'bar', new Date()),
+      put (sub3, 'baz', new Date())
+    ),
+    para (replicate(m1, m2), replicate(m2, m1)),
+    para (replicate(m2, m3), replicate(m3, m2)),
+    para (replicate(m1, m3), replicate(m3, m1)),
+    para (all(db1), all (db2), all(db3))
+  ) (function (err, all) {
+      t.notOk(err)
+      //assert that both databases are equal!
+      // console.log(all)
+      t.deepEqual(all[0], all[1])
+      t.deepEqual(all[0], all[2])
+      t.end()
+    })
+})

--- a/test/replicate-sublevels.js
+++ b/test/replicate-sublevels.js
@@ -37,11 +37,105 @@ test('replicate sublevels 1', function (t) {
     replicate(m1, m2),
     para(all(db1), all(db2))
   )(function (err, all) {
-    console.log('err', err)
     t.notOk(err)
     //assert that both databases are equal!
     console.log(all)
     t.deepEqual(all[0], all[1])
     t.end()
   })
+})
+
+test('replicate sublevels 2', function (t) {
+
+  var db1 = sublevel(level('replicate2_1'))
+  var db2 = sublevel(level('replicate2_2'))
+
+  var sub1 = db1.sublevel('data').sublevel('sub1')
+  var sub2 = db2.sublevel('data').sublevel('sub2')
+
+  var m1 = master(db1, 'master', "M1", {recursive: true})
+  var m2 = master(db2, 'master', "M2", {recursive: true})
+
+  series(
+    para(
+      put(sub1, 'foo', new Date()),
+      put(sub2, 'bar', new Date())
+    ),
+    para(replicate(m1, m2), replicate(m2, m1)),
+    para(all (db1), all(db2))
+  )(function (err, all) {
+    t.notOk(err)
+    //assert that both databases are equal!
+    console.log(all)
+    t.deepEqual(all[0], all[1])
+    t.end()
+  })
+})
+
+test('replicate sublevels 3', function (t) {
+
+  var db1 = sublevel(level('replicate3_1'))
+  var db2 = sublevel(level('replicate3_2'))
+  var db3 = sublevel(level('replicate3_3'))
+
+  var sub1 = db1.sublevel('data').sublevel('sub1')
+  var sub2 = db2.sublevel('data').sublevel('sub2')
+  var sub3 = db3.sublevel('data').sublevel('sub2')
+
+  var m1 = master(db1, 'master', "M1", {recursive: true})
+  var m2 = master(db2, 'master', "M2", {recursive: true})
+  var m3 = master(db3, 'master', "M3", {recursive: true})
+
+  series (
+    para (
+      put (sub1, 'foo', new Date()),
+      put (sub2, 'bar', new Date()),
+      put (sub3, 'baz', new Date())
+    ),
+    para (replicate(m1, m2), replicate(m2, m1)),
+    para (replicate(m2, m3), replicate(m3, m2)),
+    para (replicate(m1, m3), replicate(m3, m1)),
+    para (all(db1), all (db2), all(db3))
+  ) (function (err, all) {
+      t.notOk(err)
+      //assert that both databases are equal!
+      // console.log(all)
+      t.deepEqual(all[0], all[1])
+      t.deepEqual(all[0], all[2])
+      t.end()
+    })
+})
+
+test('replicate sublevels 3 - separate master', function (t) {
+
+  var db1 = sublevel(level('replicate3sep_1'))
+  var db2 = sublevel(level('replicate3sep_2'))
+  var db3 = sublevel(level('replicate3sep_3'))
+
+  var sub1 = db1.sublevel('data').sublevel('sub1')
+  var sub2 = db2.sublevel('data').sublevel('sub2')
+  var sub3 = db3.sublevel('data').sublevel('sub2')
+
+  var m1 = master(db1, db1.sublevel('m'), "M1", {recursive: true})
+  var m2 = master(db2, db2.sublevel('m'), "M2", {recursive: true})
+  var m3 = master(db3, db3.sublevel('m'), "M3", {recursive: true})
+
+  series (
+    para (
+      put (sub1, 'foo', new Date()),
+      put (sub2, 'bar', new Date()),
+      put (sub3, 'baz', new Date())
+    ),
+    para (replicate(m1, m2), replicate(m2, m1)),
+    para (replicate(m2, m3), replicate(m3, m2)),
+    para (replicate(m1, m3), replicate(m3, m1)),
+    para (all(db1), all (db2), all(db3))
+  ) (function (err, all) {
+      t.notOk(err)
+      //assert that both databases are equal!
+      // console.log(all)
+      t.deepEqual(all[0], all[1])
+      t.deepEqual(all[0], all[2])
+      t.end()
+    })
 })

--- a/test/replicate-sublevels.js
+++ b/test/replicate-sublevels.js
@@ -29,79 +29,19 @@ test('replicate sublevels 1', function (t) {
 
   var sub1 = db1.sublevel('sub1').sublevel('sub2')
 
-  var m1 = master(db1, 'master', "M1", '\xffsub1\xff')
-  var m2 = master(db2, 'master', "M2", '\xffsub1\xff')
+  var m1 = master(db1, 'master', "M1", {recursive: true})
+  var m2 = master(db2, 'master', "M2", {recursive: true})
 
   series(
     put(sub1, 'foo', new Date()),
     replicate(m1, m2),
     para(all(db1), all(db2))
   )(function (err, all) {
+    console.log('err', err)
     t.notOk(err)
     //assert that both databases are equal!
     console.log(all)
     t.deepEqual(all[0], all[1])
     t.end()
   })
-})
-
-test('replicate sublevels 2', function (t) {
-
-  var db1 = sublevel(level('replicate2_1'))
-  var db2 = sublevel(level('replicate2_2'))
-
-  var sub1 = db1.sublevel('data').sublevel('sub1')
-  var sub2 = db2.sublevel('data').sublevel('sub2')
-
-  var m1 = master(db1, 'master', "M1", db1.sublevel('data').prefix())
-  var m2 = master(db2, 'master', "M2", db2.sublevel('data').prefix())
-
-  series(
-    para(
-      put(sub1, 'foo', new Date()),
-      put(sub2, 'bar', new Date())
-    ),
-    para(replicate(m1, m2), replicate(m2, m1)),
-    para(all (db1), all(db2))
-  )(function (err, all) {
-    t.notOk(err)
-    //assert that both databases are equal!
-    console.log(all)
-    t.deepEqual(all[0], all[1])
-    t.end()
-  })
-})
-
-test('replicate sublevels 3', function (t) {
-
-  var db1 = sublevel(level('replicate3_1'))
-  var db2 = sublevel(level('replicate3_2'))
-  var db3 = sublevel(level('replicate3_3'))
-
-  var sub1 = db1.sublevel('data').sublevel('sub1')
-  var sub2 = db2.sublevel('data').sublevel('sub2')
-  var sub3 = db3.sublevel('data').sublevel('sub2')
-
-  var m1 = master(db1, 'master', "M1", db1.sublevel('data').prefix())
-  var m2 = master(db2, 'master', "M2", db2.sublevel('data').prefix())
-  var m3 = master(db3, 'master', "M3", db3.sublevel('data').prefix())
-
-  series (
-    para (
-      put (sub1, 'foo', new Date()),
-      put (sub2, 'bar', new Date()),
-      put (sub3, 'baz', new Date())
-    ),
-    para (replicate(m1, m2), replicate(m2, m1)),
-    para (replicate(m2, m3), replicate(m3, m2)),
-    para (replicate(m1, m3), replicate(m3, m1)),
-    para (all(db1), all (db2), all(db3))
-  ) (function (err, all) {
-      t.notOk(err)
-      //assert that both databases are equal!
-      // console.log(all)
-      t.deepEqual(all[0], all[1])
-      t.deepEqual(all[0], all[2])
-      t.end()
-    })
 })

--- a/test/util.js
+++ b/test/util.js
@@ -88,7 +88,7 @@ exports.observePull = function obPull (s) {
   return v
 }
 
-exports.eventuallyConsistent = function (d1, d2, delay) {
+exports.eventuallyConsistent = function (d1, d2, delay, cb) {
   delay = delay || 100
   var h1, h2
   var consistent = o.compute([
@@ -113,6 +113,7 @@ exports.eventuallyConsistent = function (d1, d2, delay) {
     console.log(h1() + ' === ' + h2())
     assert.ok(consistent())
     assert.equal(h1(), h2())
+    if (cb) cb()
   }
 }
 


### PR DESCRIPTION
I'm not thrilled about the api for this, but I like that it's nonbreaking. I'm trying to allow `level-replicate` to be used to replicate a whole level instance so you can run a cluster of database instances where every node is a master. When a node is spawned, it can contact the other database nodes and start replication of all content (included changes made to sublevels). Is there a better way to do this API?
